### PR TITLE
Migrate tests to use alcotest for quiet output behavior

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -32,13 +32,13 @@
   (progn
    (run %{test}))))
 
-(executable
+(test
  (name test_framebuf_assertion)
- (libraries hardcaml base stdio ppu))
+ (libraries alcotest hardcaml base stdio ppu))
 
 
 (test
  (name test_bg_fetcher)
- (libraries hardcaml hardcaml_waveterm base stdio ppu)
+ (libraries alcotest hardcaml hardcaml_waveterm base stdio ppu)
  (flags
   (:standard -w +26+8+11 -warn-error +26+8+11)))

--- a/test/test_bg_fetcher.ml
+++ b/test/test_bg_fetcher.ml
@@ -764,27 +764,62 @@ let test_control_signals () =
     printf "  ✗ Control signals test failed: %s\n" (Exn.to_string exn) ;
     raise exn
 
-(** Main test function *)
-let () =
-  printf "=== Background Fetcher Comprehensive Tests ===\n\n" ;
-
-  try
-    (* Run all core PPU behavior tests *)
-    test_tilemap_addressing () ;
-    test_tile_data_decoding () ;
-    test_bgp_palette () ;
-
-    (* These tests require the actual bg_fetcher implementation *)
-    printf "\nTests requiring bg_fetcher implementation:\n" ;
-    test_state_transitions () ;
-    test_fetch_timing () ;
-    test_checkerboard_output () ;
-    test_control_signals () ;
-
-    printf "\n=== All background fetcher tests completed! ===\n" ;
-    printf
-      "Note: Some tests are framework placeholders pending bg_fetcher_dmg implementation\n"
+(** Convert test functions to alcotest test cases *)
+let test_tilemap_addressing_case () = 
+  try 
+    test_tilemap_addressing ()
   with exn ->
-    printf "\n=== TEST FAILED ===\n" ;
-    printf "Error: %s\n" (Exn.to_string exn) ;
-    Stdlib.exit 1
+    Alcotest.failf "Tilemap addressing test failed: %s" (Exn.to_string exn)
+
+let test_tile_data_decoding_case () = 
+  try 
+    test_tile_data_decoding ()
+  with exn ->
+    Alcotest.failf "Tile data decoding test failed: %s" (Exn.to_string exn)
+
+let test_bgp_palette_case () = 
+  try 
+    test_bgp_palette ()
+  with exn ->
+    Alcotest.failf "BGP palette test failed: %s" (Exn.to_string exn)
+
+let test_state_transitions_case () = 
+  try 
+    test_state_transitions ()
+  with exn ->
+    Alcotest.failf "State transitions test failed: %s" (Exn.to_string exn)
+
+let test_fetch_timing_case () = 
+  try 
+    test_fetch_timing ()
+  with exn ->
+    Alcotest.failf "Fetch timing test failed: %s" (Exn.to_string exn)
+
+let test_checkerboard_output_case () = 
+  try 
+    test_checkerboard_output ()
+  with exn ->
+    Alcotest.failf "Checkerboard output test failed: %s" (Exn.to_string exn)
+
+let test_control_signals_case () = 
+  try 
+    test_control_signals ()
+  with exn ->
+    Alcotest.failf "Control signals test failed: %s" (Exn.to_string exn)
+
+(** Main test function using alcotest *)
+let () =
+  let open Alcotest in
+  run "Background Fetcher Tests" [
+    "core-ppu-behavior", [
+      test_case "Tilemap addressing" `Quick test_tilemap_addressing_case;
+      test_case "Tile data decoding" `Quick test_tile_data_decoding_case;
+      test_case "BGP palette application" `Quick test_bgp_palette_case;
+    ];
+    "bg-fetcher-implementation", [
+      test_case "State machine transitions" `Slow test_state_transitions_case;
+      test_case "Fetch timing verification" `Slow test_fetch_timing_case;
+      test_case "Checkerboard output generation" `Slow test_checkerboard_output_case;
+      test_case "Control signals handling" `Slow test_control_signals_case;
+    ];
+  ]

--- a/test/test_bg_fetcher.ml
+++ b/test/test_bg_fetcher.ml
@@ -765,61 +765,47 @@ let test_control_signals () =
     raise exn
 
 (** Convert test functions to alcotest test cases *)
-let test_tilemap_addressing_case () = 
-  try 
-    test_tilemap_addressing ()
-  with exn ->
-    Alcotest.failf "Tilemap addressing test failed: %s" (Exn.to_string exn)
+let test_tilemap_addressing_case () =
+  try test_tilemap_addressing ()
+  with exn -> Alcotest.failf "Tilemap addressing test failed: %s" (Exn.to_string exn)
 
-let test_tile_data_decoding_case () = 
-  try 
-    test_tile_data_decoding ()
-  with exn ->
-    Alcotest.failf "Tile data decoding test failed: %s" (Exn.to_string exn)
+let test_tile_data_decoding_case () =
+  try test_tile_data_decoding ()
+  with exn -> Alcotest.failf "Tile data decoding test failed: %s" (Exn.to_string exn)
 
-let test_bgp_palette_case () = 
-  try 
-    test_bgp_palette ()
-  with exn ->
-    Alcotest.failf "BGP palette test failed: %s" (Exn.to_string exn)
+let test_bgp_palette_case () =
+  try test_bgp_palette ()
+  with exn -> Alcotest.failf "BGP palette test failed: %s" (Exn.to_string exn)
 
-let test_state_transitions_case () = 
-  try 
-    test_state_transitions ()
-  with exn ->
-    Alcotest.failf "State transitions test failed: %s" (Exn.to_string exn)
+let test_state_transitions_case () =
+  try test_state_transitions ()
+  with exn -> Alcotest.failf "State transitions test failed: %s" (Exn.to_string exn)
 
-let test_fetch_timing_case () = 
-  try 
-    test_fetch_timing ()
-  with exn ->
-    Alcotest.failf "Fetch timing test failed: %s" (Exn.to_string exn)
+let test_fetch_timing_case () =
+  try test_fetch_timing ()
+  with exn -> Alcotest.failf "Fetch timing test failed: %s" (Exn.to_string exn)
 
-let test_checkerboard_output_case () = 
-  try 
-    test_checkerboard_output ()
-  with exn ->
-    Alcotest.failf "Checkerboard output test failed: %s" (Exn.to_string exn)
+let test_checkerboard_output_case () =
+  try test_checkerboard_output ()
+  with exn -> Alcotest.failf "Checkerboard output test failed: %s" (Exn.to_string exn)
 
-let test_control_signals_case () = 
-  try 
-    test_control_signals ()
-  with exn ->
-    Alcotest.failf "Control signals test failed: %s" (Exn.to_string exn)
+let test_control_signals_case () =
+  try test_control_signals ()
+  with exn -> Alcotest.failf "Control signals test failed: %s" (Exn.to_string exn)
 
 (** Main test function using alcotest *)
 let () =
   let open Alcotest in
-  run "Background Fetcher Tests" [
-    "core-ppu-behavior", [
-      test_case "Tilemap addressing" `Quick test_tilemap_addressing_case;
-      test_case "Tile data decoding" `Quick test_tile_data_decoding_case;
-      test_case "BGP palette application" `Quick test_bgp_palette_case;
-    ];
-    "bg-fetcher-implementation", [
-      test_case "State machine transitions" `Slow test_state_transitions_case;
-      test_case "Fetch timing verification" `Slow test_fetch_timing_case;
-      test_case "Checkerboard output generation" `Slow test_checkerboard_output_case;
-      test_case "Control signals handling" `Slow test_control_signals_case;
-    ];
-  ]
+  run "Background Fetcher Tests"
+    [ ( "core-ppu-behavior"
+      , [ test_case "Tilemap addressing" `Quick test_tilemap_addressing_case
+        ; test_case "Tile data decoding" `Quick test_tile_data_decoding_case
+        ; test_case "BGP palette application" `Quick test_bgp_palette_case
+        ] )
+    ; ( "bg-fetcher-implementation"
+      , [ test_case "State machine transitions" `Slow test_state_transitions_case
+        ; test_case "Fetch timing verification" `Slow test_fetch_timing_case
+        ; test_case "Checkerboard output generation" `Slow test_checkerboard_output_case
+        ; test_case "Control signals handling" `Slow test_control_signals_case
+        ] )
+    ]

--- a/test/test_framebuf_assertion.ml
+++ b/test/test_framebuf_assertion.ml
@@ -70,4 +70,18 @@ let test_framebuf_address_assertion () =
   printf "      and can be observed in waveforms for debugging purposes.\n" ;
   printf "      Address range: 0 to 23039 (160*144-1) for GameBoy screen.\n"
 
-let () = test_framebuf_address_assertion ()
+(** Convert to alcotest test case *)
+let test_framebuf_address_assertion_case () = 
+  try 
+    test_framebuf_address_assertion ()
+  with exn ->
+    Alcotest.failf "Framebuffer address assertion test failed: %s" (Exn.to_string exn)
+
+(** Main test function using alcotest *)
+let () =
+  let open Alcotest in
+  run "Framebuffer Assertion Tests" [
+    "framebuffer", [
+      test_case "Address assertion mechanism" `Quick test_framebuf_address_assertion_case;
+    ];
+  ]

--- a/test/test_framebuf_assertion.ml
+++ b/test/test_framebuf_assertion.ml
@@ -71,17 +71,17 @@ let test_framebuf_address_assertion () =
   printf "      Address range: 0 to 23039 (160*144-1) for GameBoy screen.\n"
 
 (** Convert to alcotest test case *)
-let test_framebuf_address_assertion_case () = 
-  try 
-    test_framebuf_address_assertion ()
+let test_framebuf_address_assertion_case () =
+  try test_framebuf_address_assertion ()
   with exn ->
     Alcotest.failf "Framebuffer address assertion test failed: %s" (Exn.to_string exn)
 
 (** Main test function using alcotest *)
 let () =
   let open Alcotest in
-  run "Framebuffer Assertion Tests" [
-    "framebuffer", [
-      test_case "Address assertion mechanism" `Quick test_framebuf_address_assertion_case;
-    ];
-  ]
+  run "Framebuffer Assertion Tests"
+    [ ( "framebuffer"
+      , [ test_case "Address assertion mechanism" `Quick
+            test_framebuf_address_assertion_case
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- Migrates `test_bg_fetcher.ml` and `test_framebuf_assertion.ml` to use the alcotest framework
- Updates dune configuration to include alcotest library dependencies
- Maintains all existing test functionality while providing consistent quiet output behavior

## Changes Made
- **test_bg_fetcher.ml**: Converted to alcotest with organized test suites
  - Core PPU behavior tests (marked as `Quick`)  
  - Background fetcher implementation tests (marked as `Slow`)
- **test_framebuf_assertion.ml**: Converted to alcotest framework
- **test/dune**: Added alcotest library dependencies and converted executable to test

## Benefits
- **Quiet when passing**: Tests only show minimal success output
- **Verbose when failing**: Detailed failure information displayed only when needed
- **Consistent behavior**: All tests now use the same framework as oracle lockstep
- **Better organization**: Tests grouped into logical suites with speed classifications
- **Selective execution**: Can run only quick tests with `make test -q`

## Testing
- ✅ All tests pass with `make test`
- ✅ Clean builds work with `make clean && make test`
- ✅ Oracle lockstep test continues to work correctly
- ✅ Quiet output behavior verified

The build system properly handles dependencies - `make test` automatically builds required tools and ROMs before running tests.

🤖 Generated with [Claude Code](https://claude.ai/code)