### PR TITLE
feat: Add jules-setup.sh script for nix-portable

### DIFF
--- a/tools/jules-setup.sh
+++ b/tools/jules-setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# This script sets up the nix-portable environment for Jules.
+set -euo pipefail
+
+echo "--- Setting up nix-portable for Jules ---"
+
+# 1) Download nix-portable if it's not already present
+if [ ! -f "./nix-portable" ]; then
+  echo "Downloading nix-portable..."
+  curl -L https://github.com/DavHau/nix-portable/releases/latest/download/nix-portable-$(uname -m) > nix-portable
+  chmod +x ./nix-portable
+else
+  echo "nix-portable already exists."
+fi
+
+# 2) Create a 'nix' symlink for convenience
+ln -sf ./nix-portable ./nix
+
+echo "nix-portable setup is complete."
+echo "You can now use './nix' to run commands."
+echo "Remember to set NIX_CONFIG and NP_LOCATION environment variables."
+echo "Example: ./nix develop .#default --command 'make build'"


### PR DESCRIPTION
This commit adds a new script at tools/jules-setup.sh. This script is intended for use by the agent (Jules) to set up a local development environment using nix-portable without requiring a system-wide Nix installation.

As per the user's final instructions, this script is for interactive use and does not modify the existing CI workflow.